### PR TITLE
Fix build and tests

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatalf("Failed to connect: %v", err)
 	}
 	defer conn.Close()
-	client := pb.NewDot1xManagerClient(conn)
+	client := pb.NewDot1XManagerClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -79,7 +79,7 @@ func main() {
 		"TTLS": pb.EapType_EAP_TTLS,
 	}[(*eap)]
 
-	req := &pb.Dot1xConfigRequest{
+	req := &pb.Dot1XConfigRequest{
 		Interface:  *iface,
 		EapType:    eapType,
 		Identity:   *identity,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	s := grpc.NewServer()
 	service := grpcapi.NewDot1xService()
-	pb.RegisterDot1xManagerServer(s, service)
+	pb.RegisterDot1XManagerServer(s, service)
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/examples/bulk_config.go
+++ b/examples/bulk_config.go
@@ -1,3 +1,5 @@
+//go:build examples
+
 package main
 
 import (
@@ -18,7 +20,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewDot1xManagerClient(conn)
+	client := pb.NewDot1XManagerClient(conn)
 	var wg sync.WaitGroup
 
 	for i := 1; i <= 8; i++ {
@@ -34,11 +36,11 @@ func main() {
 	log.Println("All interfaces configured.")
 }
 
-func configure(client pb.Dot1xManagerClient, iface string) {
+func configure(client pb.Dot1XManagerClient, iface string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	req := &pb.Dot1xConfigRequest{
+	req := &pb.Dot1XConfigRequest{
 		Interface:  iface,
 		EapType:    pb.EapType_EAP_PEAP,
 		Identity:   "testuser",
@@ -51,4 +53,5 @@ func configure(client pb.Dot1xManagerClient, iface string) {
 		log.Printf("[%s] Error: %v", iface, err)
 		return
 	}
-	log.Printf("[%s] %v - %s", iface, resp.Su
+	log.Printf("[%s] %v - %s", iface, resp.Success, resp.Message)
+}

--- a/examples/bulk_disconnect.go
+++ b/examples/bulk_disconnect.go
@@ -1,3 +1,5 @@
+//go:build examples
+
 package main
 
 import (
@@ -18,7 +20,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	client := pb.NewDot1xManagerClient(conn)
+	client := pb.NewDot1XManagerClient(conn)
 	var wg sync.WaitGroup
 
 	for i := 1; i <= 8; i++ {
@@ -34,7 +36,7 @@ func main() {
 	log.Println("All interfaces disconnected.")
 }
 
-func disconnect(client pb.Dot1xManagerClient, iface string) {
+func disconnect(client pb.Dot1XManagerClient, iface string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/dbus/api.go
+++ b/internal/dbus/api.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "github.com/godbus/dbus/v5"
+
+// SupplicantAPI defines the interface implemented by SupplicantClient.
+type SupplicantAPI interface {
+	CreateInterface(ifname string) (dbus.ObjectPath, error)
+	RemoveInterface(path dbus.ObjectPath) error
+	GetInterfacePathByName(ifname string) (dbus.ObjectPath, error)
+	AddNetwork(ifacePath dbus.ObjectPath, config map[string]string) (dbus.ObjectPath, error)
+	SelectNetwork(ifacePath, networkPath dbus.ObjectPath) error
+	DisconnectNetwork(ifacePath dbus.ObjectPath) error
+	Close()
+}

--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Dot1xService struct {
-	pb.UnimplementedDot1xManagerServer
+	pb.UnimplementedDot1XManagerServer
 	manager *core.InterfaceManager
 }
 
@@ -22,7 +22,12 @@ func NewDot1xService() *Dot1xService {
 	return &Dot1xService{manager: manager}
 }
 
-func (s *Dot1xService) ConfigureInterface(ctx context.Context, req *pb.Dot1xConfigRequest) (*pb.Dot1xConfigResponse, error) {
+// NewDot1xServiceWithManager creates a service using the provided manager.
+func NewDot1xServiceWithManager(m *core.InterfaceManager) *Dot1xService {
+	return &Dot1xService{manager: m}
+}
+
+func (s *Dot1xService) ConfigureInterface(ctx context.Context, req *pb.Dot1XConfigRequest) (*pb.Dot1XConfigResponse, error) {
 	select {
 	case <-ctx.Done():
 		log.Println("[WARN] ConfigureInterface canceled")
@@ -58,7 +63,7 @@ func (s *Dot1xService) GetStatus(ctx context.Context, req *pb.InterfaceRequest) 
 	}, nil
 }
 
-func (s *Dot1xService) StreamStatus(req *pb.InterfaceRequest, stream pb.Dot1xManager_StreamStatusServer) error {
+func (s *Dot1xService) StreamStatus(req *pb.InterfaceRequest, stream pb.Dot1XManager_StreamStatusServer) error {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
## Summary
- implement dbus SupplicantAPI interface and wire it up
- fix proto naming references (`Dot1X*`)
- add examples build tag and complete example function
- support injecting custom manager for gRPC service
- use bufconn.Listen in tests and mock supplicant

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687126b15fb4832aac4ec80db33f8101